### PR TITLE
Fix warnings due to improper exclusion; update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ playground.xcworkspace
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
 # Packages/
 .build/
+.swiftpm
 
 # CocoaPods
 #

--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,7 @@ let package = Package(
         .target(
             name: "Cryptor",
             dependencies: targetDependencies,
-            exclude: ["Cryptor.xcodeproj", "README.md", "Sources/Info.plist"]),
+            exclude: ["Info.plist"]),
         .testTarget(
             name: "CryptorTests",
             dependencies: ["Cryptor"]),


### PR DESCRIPTION
Fix warnings due to improper exclusion in Package.swift file. 

Same fixes as in https://github.com/Kitura/BlueSocket/pull/206